### PR TITLE
fixing reading in best models error

### DIFF
--- a/R/input.R
+++ b/R/input.R
@@ -103,7 +103,8 @@ reader <- function(f,decode,offset) {
   }
 
   message("reading from ",files[[2]])
-  models <- try(read.table(files[[2]], as.is=TRUE, header=FALSE, skip=1, comment.char="", fill=TRUE)) # sometimes file is empty
+  ncol <- max(count.fields(files[[2]], sep = "\t"))
+  models<-read.table(files[[2]], header=F, sep='\t',comment.char="", skip=1, fill=T, col.names=paste0('V', seq_len(ncol))) # sometimes file is empty
   if(inherits(models, "try-error"))
       return(NULL)
 


### PR DESCRIPTION
Dear Chris,

I came across a problem when reading in the input from GEUSS which I haven't seen before (doesn't mean it didn't exist). Basically when the first few visits have, e.g. one variant in the model, then lower down there are larger models, the 'fill=TRUE' does't work and a new line is generated for the additional variable in the model with NA in the rest of the columns.

All I've changed is the two lines in 'input.R' listed below.

Hope it's helpful!

Best wishes,

Jamie